### PR TITLE
fix: use Keyword instead of ControlNumber for job lookup

### DIFF
--- a/src/tools/advisor.ts
+++ b/src/tools/advisor.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { searchJobs, type SearchResultItem } from '../api/usajobs-client.js';
 import { getCodelist } from '../cache/codelist-cache.js';
 import { lookupConcept } from '../data/federal-glossary.js';
+import { JOB_LOOKUP_PAGE_SIZE } from './search.js';
 import { requireCV } from './cv.js';
 
 export async function handleExplainConcept(params: {
@@ -223,7 +224,7 @@ export async function handleCheckQualification(
   try {
     searchResult = await searchJobs(client, {
       Keyword: params.job_id,
-      ResultsPerPage: 10,
+      ResultsPerPage: JOB_LOOKUP_PAGE_SIZE,
     });
   } catch {
     return {

--- a/src/tools/advisor.ts
+++ b/src/tools/advisor.ts
@@ -223,7 +223,7 @@ export async function handleCheckQualification(
   try {
     searchResult = await searchJobs(client, {
       Keyword: params.job_id,
-      ResultsPerPage: 1,
+      ResultsPerPage: 10,
     });
   } catch {
     return {

--- a/src/tools/advisor.ts
+++ b/src/tools/advisor.ts
@@ -222,7 +222,7 @@ export async function handleCheckQualification(
   let searchResult;
   try {
     searchResult = await searchJobs(client, {
-      ControlNumber: params.job_id,
+      Keyword: params.job_id,
       ResultsPerPage: 1,
     });
   } catch {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -119,7 +119,7 @@ export async function handleGetJobDetails(
   let searchResult;
   try {
     searchResult = await searchJobs(client, {
-      ControlNumber: params.job_id,
+      Keyword: params.job_id,
       ResultsPerPage: 1,
     });
   } catch {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -120,7 +120,7 @@ export async function handleGetJobDetails(
   try {
     searchResult = await searchJobs(client, {
       Keyword: params.job_id,
-      ResultsPerPage: 1,
+      ResultsPerPage: 10,
     });
   } catch {
     return {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -3,6 +3,8 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { searchJobs, type SearchParams, type SearchResultItem } from '../api/usajobs-client.js';
 import { resolveCode } from '../cache/codelist-cache.js';
 
+export const JOB_LOOKUP_PAGE_SIZE = 10;
+
 interface SearchJobsParams {
   keyword?: string;
   location?: string;
@@ -120,7 +122,7 @@ export async function handleGetJobDetails(
   try {
     searchResult = await searchJobs(client, {
       Keyword: params.job_id,
-      ResultsPerPage: 10,
+      ResultsPerPage: JOB_LOOKUP_PAGE_SIZE,
     });
   } catch {
     return {

--- a/tests/tools/advisor.test.ts
+++ b/tests/tools/advisor.test.ts
@@ -135,8 +135,13 @@ describe('advisor tools', () => {
 
       const client = {} as any;
       const result = await handleCheckQualification(client, { job_id: '12345' });
-      const parsed = JSON.parse(result.content[0].text);
 
+      expect(searchJobs).toHaveBeenCalledWith(
+        client,
+        expect.objectContaining({ Keyword: '12345', ResultsPerPage: 10 }),
+      );
+
+      const parsed = JSON.parse(result.content[0].text);
       expect(parsed.cv).toContain('Senior Developer');
       expect(parsed.job.title).toBe('Software Developer');
       expect(parsed.job.key_requirements).toBeDefined();

--- a/tests/tools/advisor.test.ts
+++ b/tests/tools/advisor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'node:fs/promises';
+import { JOB_LOOKUP_PAGE_SIZE } from '../../src/tools/search.js';
 
 vi.mock('node:fs/promises');
 vi.mock('../../src/api/usajobs-client.js', () => ({
@@ -138,7 +139,7 @@ describe('advisor tools', () => {
 
       expect(searchJobs).toHaveBeenCalledWith(
         client,
-        expect.objectContaining({ Keyword: '12345', ResultsPerPage: 10 }),
+        expect.objectContaining({ Keyword: '12345', ResultsPerPage: JOB_LOOKUP_PAGE_SIZE }),
       );
 
       const parsed = JSON.parse(result.content[0].text);

--- a/tests/tools/search.test.ts
+++ b/tests/tools/search.test.ts
@@ -101,7 +101,7 @@ describe('search tools', () => {
   });
 
   describe('handleGetJobDetails', () => {
-    it('returns full job details', async () => {
+    it('searches by Keyword with job_id and returns full details', async () => {
       const { searchJobs } = await import('../../src/api/usajobs-client.js');
       const { handleGetJobDetails } = await import('../../src/tools/search.js');
 
@@ -120,11 +120,33 @@ describe('search tools', () => {
 
       const client = {} as any;
       const result = await handleGetJobDetails(client, { job_id: '12345' });
-      const parsed = JSON.parse(result.content[0].text);
 
+      expect(searchJobs).toHaveBeenCalledWith(
+        client,
+        expect.objectContaining({ Keyword: '12345', ResultsPerPage: 10 }),
+      );
+
+      const parsed = JSON.parse(result.content[0].text);
       expect(parsed.title).toBe('Developer');
       expect(parsed.major_duties).toHaveLength(2);
       expect(parsed.qualification_summary).toBe('Qualifications here');
+    });
+
+    it('returns error when job not found in results', async () => {
+      const { searchJobs } = await import('../../src/api/usajobs-client.js');
+      const { handleGetJobDetails } = await import('../../src/tools/search.js');
+
+      vi.mocked(searchJobs).mockResolvedValueOnce({
+        SearchResultCount: 1,
+        SearchResultCountAll: 1,
+        SearchResultItems: [mockJobItem({ id: '99999' })],
+      });
+
+      const client = {} as any;
+      const result = await handleGetJobDetails(client, { job_id: '12345' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Job not found');
     });
   });
 });

--- a/tests/tools/search.test.ts
+++ b/tests/tools/search.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { JOB_LOOKUP_PAGE_SIZE } from '../../src/tools/search.js';
 
 vi.mock('../../src/api/usajobs-client.js', () => ({
   searchJobs: vi.fn(),
@@ -123,7 +124,7 @@ describe('search tools', () => {
 
       expect(searchJobs).toHaveBeenCalledWith(
         client,
-        expect.objectContaining({ Keyword: '12345', ResultsPerPage: 10 }),
+        expect.objectContaining({ Keyword: '12345', ResultsPerPage: JOB_LOOKUP_PAGE_SIZE }),
       );
 
       const parsed = JSON.parse(result.content[0].text);


### PR DESCRIPTION
## Summary
- Tested ControlNumber parameter against real USAJobs API — it does not filter by MatchedObjectId
- Reverted to using Keyword search with numeric job ID, which returns the correct result
- Affects `get_job_details` and `check_qualification` tools

## Test plan
- [x] Verified against real API: `Keyword=864694700` returns correct job
- [x] All 25 tests pass
- [x] TypeScript compiles cleanly