### PR TITLE
ci: add workflow_dispatch trigger to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to publish.yml so it can be manually triggered
- Needed because release-please uses GITHUB_TOKEN which doesn't trigger other workflows

## Test plan
- [x] Merge, then manually trigger publish via Actions tab