### PR TITLE
refactor: extract shared formatJob, add missing tests

### DIFF
--- a/src/tools/advisor.ts
+++ b/src/tools/advisor.ts
@@ -3,7 +3,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { searchJobs, type SearchResultItem } from '../api/usajobs-client.js';
 import { getCodelist } from '../cache/codelist-cache.js';
 import { lookupConcept } from '../data/federal-glossary.js';
-import { JOB_LOOKUP_PAGE_SIZE } from './search.js';
+import { JOB_LOOKUP_PAGE_SIZE, formatJob } from './search.js';
 import { requireCV } from './cv.js';
 
 export async function handleExplainConcept(params: {
@@ -170,23 +170,7 @@ export async function handleFindMatchingJobs(
     }
   }
 
-  const formatted = allResults.map((item) => {
-    const d = item.MatchedObjectDescriptor;
-    const details = d.UserArea.Details;
-    const pay = d.PositionRemuneration[0];
-    return {
-      job_id: item.MatchedObjectId,
-      title: d.PositionTitle,
-      agency: d.OrganizationName,
-      location: d.PositionLocationDisplay,
-      salary_min: pay ? Number(pay.MinimumRange) : null,
-      salary_max: pay ? Number(pay.MaximumRange) : null,
-      grade_range: `${details.LowGrade}-${details.HighGrade}`,
-      security_clearance: details.SecurityClearance,
-      close_date: d.ApplicationCloseDate,
-      apply_url: d.ApplyURI[0] ?? d.PositionURI,
-    };
-  });
+  const formatted = allResults.map(formatJob);
 
   return {
     content: [

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -18,7 +18,7 @@ interface SearchJobsParams {
   results_per_page?: number;
 }
 
-function formatJob(item: SearchResultItem) {
+export function formatJob(item: SearchResultItem) {
   const d = item.MatchedObjectDescriptor;
   const details = d.UserArea.Details;
   const pay = d.PositionRemuneration[0];

--- a/tests/tools/advisor.test.ts
+++ b/tests/tools/advisor.test.ts
@@ -76,6 +76,18 @@ describe('advisor tools', () => {
 
       expect(text).toContain('Information Technology Management');
     });
+
+    it('returns not found message when concept is unknown everywhere', async () => {
+      const { handleExplainConcept } = await import('../../src/tools/advisor.js');
+      const { getCodelist } = await import('../../src/cache/codelist-cache.js');
+
+      vi.mocked(getCodelist).mockResolvedValue([]);
+
+      const result = await handleExplainConcept({ concept: 'xyzzy_unknown_thing' });
+      const text = result.content[0].text;
+
+      expect(text).toContain('Concept not found');
+    });
   });
 
   describe('handleFindMatchingJobs', () => {

--- a/tests/tools/cv.test.ts
+++ b/tests/tools/cv.test.ts
@@ -27,6 +27,19 @@ describe('cv tools', () => {
       );
       expect(result.content[0].text).toContain('saved');
     });
+
+    it('returns error when file system fails', async () => {
+      const { handleSaveCV } = await import('../../src/tools/cv.js');
+
+      vi.mocked(fs.mkdir).mockRejectedValueOnce(new Error('EACCES'));
+
+      const result = await handleSaveCV({
+        content: 'Some CV text',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Unable to save');
+    });
   });
 
   describe('handleGetCV', () => {

--- a/tests/tools/search.test.ts
+++ b/tests/tools/search.test.ts
@@ -78,6 +78,21 @@ describe('search tools', () => {
       expect(parsed.agencies_in_results).toContain('SSA');
     });
 
+    it('returns error when API fails', async () => {
+      const { searchJobs } = await import('../../src/api/usajobs-client.js');
+      const { resolveCode } = await import('../../src/cache/codelist-cache.js');
+      const { handleSearchJobs } = await import('../../src/tools/search.js');
+
+      vi.mocked(resolveCode).mockResolvedValue(undefined);
+      vi.mocked(searchJobs).mockRejectedValueOnce(new Error('Network error'));
+
+      const client = {} as any;
+      const result = await handleSearchJobs(client, { keyword: 'test' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Unable to search');
+    });
+
     it('resolves agency name to code via codelist', async () => {
       const { searchJobs } = await import('../../src/api/usajobs-client.js');
       const { resolveCode } = await import('../../src/cache/codelist-cache.js');


### PR DESCRIPTION
## Summary
- Export `formatJob` from search.ts, reuse in advisor.ts (removes duplicated formatting logic)
- Add test: `explain_federal_concept` returns "not found" when concept unknown everywhere
- Add test: `search_jobs` returns error when API fails
- Add test: `save_cv` returns error when file system fails

Tests: 26 → 29

## Test plan
- [x] All 29 tests pass
- [x] TypeScript compiles cleanly