### PR TITLE
feat: add compare_jobs tool, extract lookupJobById helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 build/
 dist/
 
+# Internal docs
+docs/
+
 # Logs
 logs
 *.log

--- a/src/tools/advisor.ts
+++ b/src/tools/advisor.ts
@@ -3,7 +3,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { searchJobs, type SearchResultItem } from '../api/usajobs-client.js';
 import { getCodelist } from '../cache/codelist-cache.js';
 import { lookupConcept } from '../data/federal-glossary.js';
-import { JOB_LOOKUP_PAGE_SIZE, formatJob } from './search.js';
+import { lookupJobById, formatJob } from './search.js';
 import { requireCV } from './cv.js';
 
 export async function handleExplainConcept(params: {
@@ -204,22 +204,15 @@ export async function handleCheckQualification(
     };
   }
 
-  let searchResult;
+  let item;
   try {
-    searchResult = await searchJobs(client, {
-      Keyword: params.job_id,
-      ResultsPerPage: JOB_LOOKUP_PAGE_SIZE,
-    });
+    item = await lookupJobById(client, params.job_id);
   } catch {
     return {
       content: [{ type: 'text', text: 'Unable to search USAJobs at this time. Please try again later.' }],
       isError: true,
     };
   }
-
-  const item = searchResult.SearchResultItems.find(
-    (i) => i.MatchedObjectId === params.job_id,
-  );
 
   if (!item) {
     return {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -206,11 +206,15 @@ export async function handleCompareJobs(
   }
 
   if (jobs.length === 0) {
+    const details: string[] = [];
+    if (notFound.length > 0) details.push(`Not found: ${notFound.join(', ')}`);
+    if (errors.length > 0) details.push(`Errors: ${errors.join(', ')}`);
+
     return {
       content: [
         {
           type: 'text',
-          text: `None of the requested jobs could be found. Not found: ${notFound.join(', ')}. Errors: ${errors.join(', ')}.`,
+          text: `None of the requested jobs could be found.${details.length > 0 ? ` ${details.join('. ')}.` : ''}`,
         },
       ],
       isError: true,

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -43,7 +43,7 @@ export function formatJob(item: SearchResultItem) {
   };
 }
 
-function formatJobFull(item: SearchResultItem) {
+export function formatJobFull(item: SearchResultItem) {
   const d = item.MatchedObjectDescriptor;
   const details = d.UserArea.Details;
   return {
@@ -52,6 +52,19 @@ function formatJobFull(item: SearchResultItem) {
     major_duties: details.MajorDuties,
     qualification_summary: d.QualificationSummary,
   };
+}
+
+export async function lookupJobById(
+  client: AxiosInstance,
+  jobId: string,
+): Promise<SearchResultItem | null> {
+  const result = await searchJobs(client, {
+    Keyword: jobId,
+    ResultsPerPage: JOB_LOOKUP_PAGE_SIZE,
+  });
+  return result.SearchResultItems.find(
+    (i) => i.MatchedObjectId === jobId,
+  ) ?? null;
 }
 
 export async function handleSearchJobs(
@@ -118,22 +131,15 @@ export async function handleGetJobDetails(
   client: AxiosInstance,
   params: { job_id: string },
 ): Promise<CallToolResult> {
-  let searchResult;
+  let item;
   try {
-    searchResult = await searchJobs(client, {
-      Keyword: params.job_id,
-      ResultsPerPage: JOB_LOOKUP_PAGE_SIZE,
-    });
+    item = await lookupJobById(client, params.job_id);
   } catch {
     return {
       content: [{ type: 'text', text: 'Unable to search USAJobs at this time. Please try again later.' }],
       isError: true,
     };
   }
-
-  const item = searchResult.SearchResultItems.find(
-    (i) => i.MatchedObjectId === params.job_id,
-  );
 
   if (!item) {
     return {
@@ -152,6 +158,70 @@ export async function handleGetJobDetails(
       {
         type: 'text',
         text: JSON.stringify(formatJobFull(item), null, 2),
+      },
+    ],
+  };
+}
+
+export async function handleCompareJobs(
+  client: AxiosInstance,
+  params: { job_ids: string[]; include_details?: boolean },
+): Promise<CallToolResult> {
+  const uniqueIds = [...new Set(params.job_ids)];
+
+  if (uniqueIds.length < 2 || uniqueIds.length > 5) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Please provide 2 to 5 unique job IDs to compare. Got ${uniqueIds.length}.`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const results = await Promise.allSettled(
+    uniqueIds.map((id) => lookupJobById(client, id)),
+  );
+
+  const jobs: ReturnType<typeof formatJob>[] = [];
+  const notFound: string[] = [];
+  const errors: string[] = [];
+
+  for (let i = 0; i < uniqueIds.length; i++) {
+    const result = results[i];
+    const id = uniqueIds[i];
+
+    if (result.status === 'rejected') {
+      errors.push(id);
+    } else if (result.value === null) {
+      notFound.push(id);
+    } else {
+      const formatted = params.include_details
+        ? formatJobFull(result.value)
+        : formatJob(result.value);
+      jobs.push(formatted);
+    }
+  }
+
+  if (jobs.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `None of the requested jobs could be found. Not found: ${notFound.join(', ')}. Errors: ${errors.join(', ')}.`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ jobs, not_found: notFound, errors }, null, 2),
       },
     ],
   };

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -214,7 +214,7 @@ export async function handleCompareJobs(
       content: [
         {
           type: 'text',
-          text: `None of the requested jobs could be found.${details.length > 0 ? ` ${details.join('. ')}.` : ''}`,
+          text: `None of the requested jobs could be found or retrieved.${details.length > 0 ? ` ${details.join('. ')}.` : ''}`,
         },
       ],
       isError: true,

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { AxiosInstance } from 'axios';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { handleSearchJobs, handleGetJobDetails } from './search.js';
+import { handleSearchJobs, handleGetJobDetails, handleCompareJobs } from './search.js';
 import { handleSaveCV, handleGetCV } from './cv.js';
 import {
   handleExplainConcept,
@@ -79,5 +79,15 @@ export function registerTools(server: McpServer, client: AxiosInstance): void {
       job_id: z.string().describe('Job ID (MatchedObjectId from search results)'),
     },
     async (params) => handleCheckQualification(client, params),
+  );
+
+  server.tool(
+    'compare_jobs',
+    'Compare 2-5 federal job postings side by side. Returns salary, grade, clearance, location, and more for each job. Makes one API call per job.',
+    {
+      job_ids: z.array(z.string()).describe('Array of 2-5 job IDs (MatchedObjectId from search results)'),
+      include_details: z.boolean().optional().describe('Include duties, qualifications, and job summary (default: false)'),
+    },
+    async (params) => handleCompareJobs(client, params),
   );
 }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -85,7 +85,7 @@ export function registerTools(server: McpServer, client: AxiosInstance): void {
     'compare_jobs',
     'Compare 2-5 federal job postings side by side. Returns salary, grade, clearance, location, and more for each job. Makes one API call per job.',
     {
-      job_ids: z.array(z.string()).describe('Array of 2-5 job IDs (MatchedObjectId from search results)'),
+      job_ids: z.array(z.string()).min(2).max(5).describe('Array of 2-5 job IDs (MatchedObjectId from search results)'),
       include_details: z.boolean().optional().describe('Include duties, qualifications, and job summary (default: false)'),
     },
     async (params) => handleCompareJobs(client, params),

--- a/tests/tools/advisor.test.ts
+++ b/tests/tools/advisor.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'node:fs/promises';
-import { JOB_LOOKUP_PAGE_SIZE } from '../../src/tools/search.js';
 
 vi.mock('node:fs/promises');
 vi.mock('../../src/api/usajobs-client.js', () => ({
@@ -10,6 +9,13 @@ vi.mock('../../src/cache/codelist-cache.js', () => ({
   getCodelist: vi.fn(),
   resolveCode: vi.fn(),
 }));
+vi.mock('../../src/tools/search.js', async () => {
+  const actual = await vi.importActual('../../src/tools/search.js');
+  return {
+    ...actual,
+    lookupJobById: vi.fn(),
+  };
+});
 
 // Helper to create mock job item
 function mockJobItem(overrides: Record<string, any> = {}) {
@@ -132,7 +138,7 @@ describe('advisor tools', () => {
   describe('handleCheckQualification', () => {
     it('returns CV and job data side by side', async () => {
       const { handleCheckQualification } = await import('../../src/tools/advisor.js');
-      const { searchJobs } = await import('../../src/api/usajobs-client.js');
+      const { lookupJobById } = await import('../../src/tools/search.js');
 
       const stored = {
         content: 'Senior Developer with 8 years React experience',
@@ -140,19 +146,12 @@ describe('advisor tools', () => {
         format: 'txt',
       };
       vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(stored));
-      vi.mocked(searchJobs).mockResolvedValueOnce({
-        SearchResultCount: 1,
-        SearchResultCountAll: 1,
-        SearchResultItems: [mockJobItem()],
-      });
+      vi.mocked(lookupJobById).mockResolvedValueOnce(mockJobItem());
 
       const client = {} as any;
       const result = await handleCheckQualification(client, { job_id: '12345' });
 
-      expect(searchJobs).toHaveBeenCalledWith(
-        client,
-        expect.objectContaining({ Keyword: '12345', ResultsPerPage: JOB_LOOKUP_PAGE_SIZE }),
-      );
+      expect(lookupJobById).toHaveBeenCalledWith(client, '12345');
 
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.cv).toContain('Senior Developer');

--- a/tests/tools/search.test.ts
+++ b/tests/tools/search.test.ts
@@ -165,4 +165,144 @@ describe('search tools', () => {
       expect(result.content[0].text).toContain('Job not found');
     });
   });
+
+  describe('lookupJobById', () => {
+    it('returns item when found in search results', async () => {
+      const { searchJobs } = await import('../../src/api/usajobs-client.js');
+      const { lookupJobById } = await import('../../src/tools/search.js');
+
+      vi.mocked(searchJobs).mockResolvedValueOnce({
+        SearchResultCount: 1,
+        SearchResultCountAll: 1,
+        SearchResultItems: [mockJobItem({ id: '12345' })],
+      });
+
+      const client = {} as any;
+      const item = await lookupJobById(client, '12345');
+
+      expect(item).not.toBeNull();
+      expect(item!.MatchedObjectId).toBe('12345');
+      expect(searchJobs).toHaveBeenCalledWith(
+        client,
+        expect.objectContaining({ Keyword: '12345' }),
+      );
+    });
+
+    it('returns null when job not in results', async () => {
+      const { searchJobs } = await import('../../src/api/usajobs-client.js');
+      const { lookupJobById } = await import('../../src/tools/search.js');
+
+      vi.mocked(searchJobs).mockResolvedValueOnce({
+        SearchResultCount: 1,
+        SearchResultCountAll: 1,
+        SearchResultItems: [mockJobItem({ id: '99999' })],
+      });
+
+      const client = {} as any;
+      const item = await lookupJobById(client, '12345');
+
+      expect(item).toBeNull();
+    });
+  });
+
+  describe('handleCompareJobs', () => {
+    it('compares multiple jobs and returns formatted results', async () => {
+      const { searchJobs } = await import('../../src/api/usajobs-client.js');
+      const { handleCompareJobs } = await import('../../src/tools/search.js');
+
+      vi.mocked(searchJobs)
+        .mockResolvedValueOnce({
+          SearchResultCount: 1,
+          SearchResultCountAll: 1,
+          SearchResultItems: [mockJobItem({ id: '111', title: 'Developer' })],
+        })
+        .mockResolvedValueOnce({
+          SearchResultCount: 1,
+          SearchResultCountAll: 1,
+          SearchResultItems: [mockJobItem({ id: '222', title: 'Engineer' })],
+        });
+
+      const client = {} as any;
+      const result = await handleCompareJobs(client, { job_ids: ['111', '222'] });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.jobs).toHaveLength(2);
+      expect(parsed.jobs[0].title).toBe('Developer');
+      expect(parsed.jobs[1].title).toBe('Engineer');
+      expect(parsed.not_found).toHaveLength(0);
+      expect(parsed.errors).toHaveLength(0);
+    });
+
+    it('separates not_found and errors', async () => {
+      const { searchJobs } = await import('../../src/api/usajobs-client.js');
+      const { handleCompareJobs } = await import('../../src/tools/search.js');
+
+      vi.mocked(searchJobs)
+        .mockResolvedValueOnce({
+          SearchResultCount: 1,
+          SearchResultCountAll: 1,
+          SearchResultItems: [mockJobItem({ id: '111' })],
+        })
+        .mockResolvedValueOnce({
+          SearchResultCount: 0,
+          SearchResultCountAll: 0,
+          SearchResultItems: [],
+        })
+        .mockRejectedValueOnce(new Error('API error'));
+
+      const client = {} as any;
+      const result = await handleCompareJobs(client, { job_ids: ['111', '222', '333'] });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.jobs).toHaveLength(1);
+      expect(parsed.not_found).toContain('222');
+      expect(parsed.errors).toContain('333');
+    });
+
+    it('returns error when less than 2 IDs', async () => {
+      const { handleCompareJobs } = await import('../../src/tools/search.js');
+
+      const client = {} as any;
+      const result = await handleCompareJobs(client, { job_ids: ['111'] });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('2 to 5');
+    });
+
+    it('returns error when more than 5 IDs', async () => {
+      const { handleCompareJobs } = await import('../../src/tools/search.js');
+
+      const client = {} as any;
+      const result = await handleCompareJobs(client, {
+        job_ids: ['1', '2', '3', '4', '5', '6'],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('2 to 5');
+    });
+
+    it('deduplicates job IDs', async () => {
+      const { handleCompareJobs } = await import('../../src/tools/search.js');
+
+      const client = {} as any;
+      const result = await handleCompareJobs(client, { job_ids: ['111', '111', '111'] });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('2 to 5');
+    });
+
+    it('returns isError when all jobs fail', async () => {
+      const { searchJobs } = await import('../../src/api/usajobs-client.js');
+      const { handleCompareJobs } = await import('../../src/tools/search.js');
+
+      vi.mocked(searchJobs)
+        .mockRejectedValueOnce(new Error('fail'))
+        .mockRejectedValueOnce(new Error('fail'));
+
+      const client = {} as any;
+      const result = await handleCompareJobs(client, { job_ids: ['111', '222'] });
+
+      expect(result.isError).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- New `compare_jobs` tool: compare 2-5 job postings side by side
- `Promise.allSettled` for parallel fetching, dedup input IDs
- Separate `not_found` vs `errors` in response
- Extract `lookupJobById` helper (eliminates duplicated lookup in 3 places)
- Export `formatJobFull` for reuse
- Refactor `handleGetJobDetails` and `handleCheckQualification`

Tests: 29 → 37

## Test plan
- [x] 37 tests pass
- [x] TypeScript compiles cleanly
- [x] compare_jobs: happy path, not_found/errors split, validation (2-5), dedup, all-fail
- [x] lookupJobById: found, not found