### PR TITLE
feat: add calculate_salary tool with locality pay adjustment

### DIFF
--- a/src/data/federal-glossary.ts
+++ b/src/data/federal-glossary.ts
@@ -17,7 +17,7 @@ export interface GlossaryEntry {
 // GS pay table 2026 — source: OPM Salary Table 2026-GS
 // Incorporating the 1% General Schedule Increase, Effective January 2026
 // https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/pdf/2026/GS.pdf
-const GS_STEPS: Record<string, number[]> = {
+export const GS_STEPS: Record<string, number[]> = {
   '1':  [22584, 23341, 24092, 24840, 25589, 26028, 26771, 27519, 27550, 28248],
   '2':  [25393, 25997, 26839, 27550, 27858, 28677, 29496, 30315, 31134, 31953],
   '3':  [27708, 28632, 29556, 30480, 31404, 32328, 33252, 34176, 35100, 36024],

--- a/src/data/locality-rates.ts
+++ b/src/data/locality-rates.ts
@@ -92,11 +92,8 @@ const ALIASES: Record<string, string> = {
   hawaii: 'state of hawaii',
 };
 
-const REST_OF_US: LocalityMatch = {
-  name: 'Rest of US',
-  percentage: 17.06,
-  fallback: true,
-};
+const REST_OF_US_ENTRY = LOCALITY_AREAS.find((area) => area.name === 'Rest of US')!;
+const REST_OF_US: LocalityMatch = { ...REST_OF_US_ENTRY, fallback: true };
 
 export function findLocalityArea(query: string): LocalityMatch {
   const trimmed = query.trim().toLowerCase();

--- a/src/data/locality-rates.ts
+++ b/src/data/locality-rates.ts
@@ -135,5 +135,5 @@ export function findLocalityArea(query: string): LocalityMatch {
 
   if (bestMatch && bestScore > 0) return { ...bestMatch };
 
-  return REST_OF_US;
+  return { ...REST_OF_US };
 }

--- a/src/data/locality-rates.ts
+++ b/src/data/locality-rates.ts
@@ -98,7 +98,7 @@ const REST_OF_US: LocalityMatch = { ...REST_OF_US_ENTRY, fallback: true };
 export function findLocalityArea(query: string): LocalityMatch {
   const trimmed = query.trim().toLowerCase();
 
-  if (trimmed === '') return REST_OF_US;
+  if (trimmed === '') return { ...REST_OF_US_ENTRY };
 
   // Check aliases first
   const aliasTarget = ALIASES[trimmed];

--- a/src/data/locality-rates.ts
+++ b/src/data/locality-rates.ts
@@ -1,0 +1,142 @@
+// OPM 2026 Locality Pay Area Rates
+// Source: https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2026/general-schedule/
+export const EFFECTIVE_YEAR = 2026;
+
+export interface LocalityArea {
+  name: string;
+  percentage: number;
+}
+
+export interface LocalityMatch extends LocalityArea {
+  fallback?: boolean;
+}
+
+export const LOCALITY_AREAS: LocalityArea[] = [
+  { name: 'Albany-Schenectady, NY-MA', percentage: 20.77 },
+  { name: 'Albuquerque-Santa Fe-Las Vegas, NM', percentage: 18.33 },
+  { name: 'Atlanta-Athens-Sandy Springs, GA-AL', percentage: 23.79 },
+  { name: 'Austin-Round Rock-Georgetown, TX', percentage: 20.35 },
+  { name: 'Birmingham-Hoover-Talladega, AL', percentage: 18.24 },
+  { name: 'Boston-Worcester-Providence, MA-RI-NH-CT-ME-VT', percentage: 32.58 },
+  { name: 'Buffalo-Cheektowaga-Olean, NY', percentage: 22.41 },
+  { name: 'Burlington-South Burlington-Barre, VT', percentage: 19.45 },
+  { name: 'Charlotte-Concord, NC-SC', percentage: 19.67 },
+  { name: 'Chicago-Naperville, IL-IN-WI', percentage: 30.86 },
+  { name: 'Cincinnati-Wilmington-Maysville, OH-KY-IN', percentage: 21.93 },
+  { name: 'Cleveland-Akron-Canton, OH-PA', percentage: 22.23 },
+  { name: 'Colorado Springs, CO', percentage: 20.15 },
+  { name: 'Columbus-Marion-Zanesville, OH', percentage: 22.15 },
+  { name: 'Corpus Christi-Kingsville-Alice, TX', percentage: 17.63 },
+  { name: 'Dallas-Fort Worth, TX-OK', percentage: 27.26 },
+  { name: 'Davenport-Moline, IA-IL', percentage: 18.93 },
+  { name: 'Dayton-Springfield-Kettering, OH', percentage: 21.42 },
+  { name: 'Denver-Aurora, CO', percentage: 30.52 },
+  { name: 'Des Moines-Ames-West Des Moines, IA', percentage: 18.01 },
+  { name: 'Detroit-Warren-Ann Arbor, MI', percentage: 29.12 },
+  { name: 'Fresno-Madera-Hanford, CA', percentage: 17.65 },
+  { name: 'Harrisburg-Lebanon, PA', percentage: 19.43 },
+  { name: 'Hartford-East Hartford, CT-MA', percentage: 32.08 },
+  { name: 'Houston-The Woodlands, TX', percentage: 35.00 },
+  { name: 'Huntsville-Decatur, AL-TN', percentage: 21.91 },
+  { name: 'Indianapolis-Carmel-Muncie, IN', percentage: 18.15 },
+  { name: 'Kansas City-Overland Park, MO-KS', percentage: 18.97 },
+  { name: 'Laredo, TX', percentage: 21.59 },
+  { name: 'Las Vegas-Henderson, NV-AZ', percentage: 19.57 },
+  { name: 'Los Angeles-Long Beach, CA', percentage: 36.47 },
+  { name: 'Miami-Fort Lauderdale, FL', percentage: 24.67 },
+  { name: 'Milwaukee-Racine-Waukesha, WI', percentage: 22.42 },
+  { name: 'Minneapolis-St. Paul, MN-WI', percentage: 27.62 },
+  { name: 'New York-Newark, NY-NJ-CT-PA', percentage: 37.95 },
+  { name: 'Omaha-Council Bluffs-Fremont, NE-IA', percentage: 18.23 },
+  { name: 'Palm Bay-Melbourne-Titusville, FL', percentage: 17.93 },
+  { name: 'Philadelphia-Reading-Camden, PA-NJ-DE-MD', percentage: 28.99 },
+  { name: 'Phoenix-Mesa, AZ', percentage: 22.45 },
+  { name: 'Pittsburgh-New Castle-Weirton, PA-OH-WV', percentage: 21.03 },
+  { name: 'Portland-Vancouver-Salem, OR-WA', percentage: 26.13 },
+  { name: 'Raleigh-Durham-Cary, NC', percentage: 22.24 },
+  { name: 'Reno-Fernley, NV', percentage: 17.52 },
+  { name: 'Richmond, VA', percentage: 22.28 },
+  { name: 'Rochester-Batavia-Seneca Falls, NY', percentage: 17.88 },
+  { name: 'Sacramento-Roseville, CA-NV', percentage: 29.76 },
+  { name: 'San Antonio-New Braunfels-Pearsall, TX', percentage: 18.78 },
+  { name: 'San Diego-Chula Vista-Carlsbad, CA', percentage: 33.72 },
+  { name: 'San Jose-San Francisco-Oakland, CA', percentage: 46.34 },
+  { name: 'Seattle-Tacoma, WA', percentage: 31.57 },
+  { name: 'Spokane-Spokane Valley, WA-ID', percentage: 17.67 },
+  { name: 'St. Louis-St. Charles-Farmington, MO-IL', percentage: 20.03 },
+  { name: 'Tucson-Nogales, AZ', percentage: 19.28 },
+  { name: 'Virginia Beach-Norfolk, VA-NC', percentage: 18.80 },
+  { name: 'Washington-Baltimore-Arlington, DC-MD-VA-WV-PA', percentage: 33.94 },
+  { name: 'State of Alaska', percentage: 32.36 },
+  { name: 'State of Hawaii', percentage: 22.21 },
+  { name: 'Rest of US', percentage: 17.06 },
+];
+
+const ALIASES: Record<string, string> = {
+  dc: 'washington',
+  dmv: 'washington',
+  nyc: 'new york',
+  sf: 'san francisco',
+  la: 'los angeles',
+  chi: 'chicago',
+  philly: 'philadelphia',
+  atl: 'atlanta',
+  dfw: 'dallas',
+  hou: 'houston',
+  bos: 'boston',
+  den: 'denver',
+  sea: 'seattle',
+  pdx: 'portland',
+  msp: 'minneapolis',
+  alaska: 'state of alaska',
+  hawaii: 'state of hawaii',
+};
+
+const REST_OF_US: LocalityMatch = {
+  name: 'Rest of US',
+  percentage: 17.06,
+  fallback: true,
+};
+
+export function findLocalityArea(query: string): LocalityMatch {
+  const trimmed = query.trim().toLowerCase();
+
+  if (trimmed === '') return REST_OF_US;
+
+  // Check aliases first
+  const aliasTarget = ALIASES[trimmed];
+  if (aliasTarget) {
+    const match = LOCALITY_AREAS.find((area) =>
+      area.name.toLowerCase().includes(aliasTarget),
+    );
+    if (match) return { ...match };
+  }
+
+  // Substring match
+  const substringMatch = LOCALITY_AREAS.find((area) =>
+    area.name.toLowerCase().includes(trimmed),
+  );
+  if (substringMatch) return { ...substringMatch };
+
+  // Token overlap
+  const queryTokens = trimmed.split(/[\s,\-]+/).filter((token) => token.length > 2);
+  let bestMatch: LocalityArea | undefined;
+  let bestScore = 0;
+
+  LOCALITY_AREAS
+    .filter((area) => area.name !== 'Rest of US')
+    .forEach((area) => {
+      const areaTokens = area.name.toLowerCase().split(/[\s,\-]+/);
+      const score = queryTokens.filter((queryToken) =>
+        areaTokens.some((areaToken) => areaToken.includes(queryToken)),
+      ).length;
+      if (score > bestScore) {
+        bestScore = score;
+        bestMatch = area;
+      }
+    });
+
+  if (bestMatch && bestScore > 0) return { ...bestMatch };
+
+  return REST_OF_US;
+}

--- a/src/data/locality-rates.ts
+++ b/src/data/locality-rates.ts
@@ -109,11 +109,13 @@ export function findLocalityArea(query: string): LocalityMatch {
     if (match) return { ...match };
   }
 
-  // Substring match
-  const substringMatch = LOCALITY_AREAS.find((area) =>
-    area.name.toLowerCase().includes(trimmed),
-  );
-  if (substringMatch) return { ...substringMatch };
+  // Substring match (skip for short queries to avoid ambiguous matches like "ny" → Albany)
+  if (trimmed.length >= 3) {
+    const substringMatch = LOCALITY_AREAS.find((area) =>
+      area.name.toLowerCase().includes(trimmed),
+    );
+    if (substringMatch) return { ...substringMatch };
+  }
 
   // Token overlap
   const queryTokens = trimmed.split(/[\s,\-]+/).filter((token) => token.length > 2);

--- a/src/tools/salary.ts
+++ b/src/tools/salary.ts
@@ -1,0 +1,113 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { GS_STEPS } from '../data/federal-glossary.js';
+import { findLocalityArea, EFFECTIVE_YEAR } from '../data/locality-rates.js';
+
+interface CalculateSalaryParams {
+  grade: string;
+  step?: number;
+  location?: string;
+}
+
+function normalizeGrade(grade: string): string {
+  return grade.replace(/^gs[- ]?/i, '').trim();
+}
+
+function calculateAdjustedPay(basePay: number, localityPercentage: number): number {
+  return Math.round(basePay * (1 + localityPercentage / 100));
+}
+
+export function handleCalculateSalary(params: CalculateSalaryParams): CallToolResult {
+  const grade = normalizeGrade(params.grade);
+
+  // Reject grade ranges
+  if (grade.includes('-') || grade.includes(':')) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: 'Please specify a single grade. Use search_jobs for grade ranges.',
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const steps = GS_STEPS[grade];
+  if (!steps) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Only GS grades 1-15 are supported. Got: "${params.grade}".`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const localityMatch = findLocalityArea(params.location ?? '');
+  const { name: localityArea, percentage: localityPercentage, fallback } = localityMatch;
+
+  const fallbackNote = fallback && params.location
+    ? `Location '${params.location}' not found. Using Rest of US rate (${localityPercentage}%).`
+    : undefined;
+
+  const baseNote = `Base pay + ${localityPercentage}% locality adjustment`;
+  const note = fallbackNote ?? baseNote;
+
+  if (params.step !== undefined) {
+    const stepIndex = params.step - 1;
+    const basePay = steps[stepIndex];
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              grade,
+              step: params.step,
+              base_pay: basePay,
+              locality_area: localityArea,
+              locality_percentage: localityPercentage,
+              adjusted_pay: calculateAdjustedPay(basePay, localityPercentage),
+              effective_year: EFFECTIVE_YEAR,
+              note,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  }
+
+  // All steps
+  const allSteps = steps.map((basePay, index) => ({
+    step: index + 1,
+    base_pay: basePay,
+    adjusted_pay: calculateAdjustedPay(basePay, localityPercentage),
+  }));
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            grade,
+            locality_area: localityArea,
+            locality_percentage: localityPercentage,
+            effective_year: EFFECTIVE_YEAR,
+            min_adjusted: allSteps[0].adjusted_pay,
+            max_adjusted: allSteps[allSteps.length - 1].adjusted_pay,
+            steps: allSteps,
+            note,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}

--- a/src/tools/salary.ts
+++ b/src/tools/salary.ts
@@ -9,7 +9,11 @@ interface CalculateSalaryParams {
 }
 
 function normalizeGrade(grade: string): string {
-  return grade.replace(/^gs[- ]?/i, '').trim();
+  const normalized = grade.replace(/^gs[- ]?/i, '').trim();
+  if (/^\d+$/.test(normalized)) {
+    return String(Number.parseInt(normalized, 10));
+  }
+  return normalized;
 }
 
 function calculateAdjustedPay(basePay: number, localityPercentage: number): number {
@@ -56,6 +60,17 @@ export function handleCalculateSalary(params: CalculateSalaryParams): CallToolRe
   const note = fallbackNote ?? baseNote;
 
   if (params.step !== undefined) {
+    if (!Number.isInteger(params.step) || params.step < 1 || params.step > 10) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Step must be an integer between 1 and 10. Got: ${params.step}.`,
+          },
+        ],
+        isError: true,
+      };
+    }
     const stepIndex = params.step - 1;
     const basePay = steps[stepIndex];
 

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3,6 +3,7 @@ import type { AxiosInstance } from 'axios';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { handleSearchJobs, handleGetJobDetails, handleCompareJobs } from './search.js';
 import { handleSaveCV, handleGetCV } from './cv.js';
+import { handleCalculateSalary } from './salary.js';
 import {
   handleExplainConcept,
   handleFindMatchingJobs,
@@ -89,5 +90,16 @@ export function registerTools(server: McpServer, client: AxiosInstance): void {
       include_details: z.boolean().optional().describe('Include duties, qualifications, and job summary (default: false)'),
     },
     async (params) => handleCompareJobs(client, params),
+  );
+
+  server.tool(
+    'calculate_salary',
+    'Calculate federal GS salary with locality pay adjustment. Returns base pay plus locality-adjusted pay for a specific grade, step, and location. Covers all 15 GS grades and ~58 locality pay areas.',
+    {
+      grade: z.string().describe('GS grade: "13" or "GS-13"'),
+      step: z.number().min(1).max(10).optional().describe('Step 1-10. Omit to see all 10 steps.'),
+      location: z.string().optional().describe('Location for locality pay: "Raleigh", "DC", "NYC", "San Francisco". Defaults to Rest of US.'),
+    },
+    async (params) => handleCalculateSalary(params),
   );
 }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -97,7 +97,7 @@ export function registerTools(server: McpServer, client: AxiosInstance): void {
     'Calculate federal GS salary with locality pay adjustment. Returns base pay plus locality-adjusted pay for a specific grade, step, and location. Covers all 15 GS grades and ~58 locality pay areas.',
     {
       grade: z.string().describe('GS grade: "13" or "GS-13"'),
-      step: z.number().min(1).max(10).optional().describe('Step 1-10. Omit to see all 10 steps.'),
+      step: z.number().int().min(1).max(10).optional().describe('Step 1-10. Omit to see all 10 steps.'),
       location: z.string().optional().describe('Location for locality pay: "Raleigh", "DC", "NYC", "San Francisco". Defaults to Rest of US.'),
     },
     async (params) => handleCalculateSalary(params),

--- a/tests/data/locality-rates.test.ts
+++ b/tests/data/locality-rates.test.ts
@@ -49,7 +49,7 @@ describe('locality-rates', () => {
   });
 
   it('matches by token overlap', () => {
-    const result = findLocalityArea('San Francisco');
-    expect(result.name).toContain('San Jose-San Francisco');
+    const result = findLocalityArea('Oakland Jose');
+    expect(result.name).toContain('San Jose-San Francisco-Oakland');
   });
 });

--- a/tests/data/locality-rates.test.ts
+++ b/tests/data/locality-rates.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { findLocalityArea, LOCALITY_AREAS } from '../../src/data/locality-rates.js';
+
+describe('locality-rates', () => {
+  it('has Rest of US as fallback', () => {
+    const rus = LOCALITY_AREAS.find((area) => area.name === 'Rest of US');
+    expect(rus).toBeDefined();
+    expect(rus!.percentage).toBe(17.06);
+  });
+
+  it('finds area by exact substring match', () => {
+    const result = findLocalityArea('Raleigh');
+    expect(result.name).toContain('Raleigh');
+    expect(result.percentage).toBe(22.24);
+  });
+
+  it('finds area by alias dc', () => {
+    const result = findLocalityArea('dc');
+    expect(result.name).toContain('Washington');
+    expect(result.percentage).toBe(33.94);
+  });
+
+  it('finds area by alias NYC', () => {
+    const result = findLocalityArea('nyc');
+    expect(result.name).toContain('New York');
+  });
+
+  it('finds area by alias SF', () => {
+    const result = findLocalityArea('sf');
+    expect(result.name).toContain('San Jose-San Francisco');
+    expect(result.percentage).toBe(46.34);
+  });
+
+  it('is case insensitive', () => {
+    const result = findLocalityArea('CHICAGO');
+    expect(result.name).toContain('Chicago');
+  });
+
+  it('falls back to Rest of US for unknown location', () => {
+    const result = findLocalityArea('Middle of Nowhere');
+    expect(result.name).toBe('Rest of US');
+    expect(result.fallback).toBe(true);
+  });
+
+  it('falls back to Rest of US for empty string', () => {
+    const result = findLocalityArea('');
+    expect(result.name).toBe('Rest of US');
+  });
+
+  it('matches by token overlap', () => {
+    const result = findLocalityArea('San Francisco');
+    expect(result.name).toContain('San Jose-San Francisco');
+  });
+});

--- a/tests/data/locality-rates.test.ts
+++ b/tests/data/locality-rates.test.ts
@@ -42,9 +42,10 @@ describe('locality-rates', () => {
     expect(result.fallback).toBe(true);
   });
 
-  it('falls back to Rest of US for empty string', () => {
+  it('returns Rest of US without fallback flag for empty string', () => {
     const result = findLocalityArea('');
     expect(result.name).toBe('Rest of US');
+    expect(result.fallback).toBeUndefined();
   });
 
   it('matches by token overlap', () => {

--- a/tests/tools/salary.test.ts
+++ b/tests/tools/salary.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { handleCalculateSalary } from '../../src/tools/salary.js';
+
+describe('handleCalculateSalary', () => {
+  it('calculates salary for specific grade, step, and location', () => {
+    const result = handleCalculateSalary({ grade: '13', step: 1, location: 'Raleigh' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.grade).toBe('13');
+    expect(parsed.step).toBe(1);
+    expect(parsed.base_pay).toBe(90925);
+    expect(parsed.locality_area).toContain('Raleigh');
+    expect(parsed.locality_percentage).toBe(22.24);
+    expect(parsed.adjusted_pay).toBe(Math.round(90925 * 1.2224));
+    expect(parsed.effective_year).toBe(2026);
+  });
+
+  it('returns all 10 steps when step not specified', () => {
+    const result = handleCalculateSalary({ grade: '13', location: 'DC' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.steps).toHaveLength(10);
+    expect(parsed.min_adjusted).toBeDefined();
+    expect(parsed.max_adjusted).toBeDefined();
+    expect(parsed.min_adjusted).toBe(parsed.steps[0].adjusted_pay);
+    expect(parsed.max_adjusted).toBe(parsed.steps[9].adjusted_pay);
+  });
+
+  it('normalizes GS-13 to 13', () => {
+    const result = handleCalculateSalary({ grade: 'GS-13', step: 1 });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.grade).toBe('13');
+    expect(parsed.base_pay).toBe(90925);
+  });
+
+  it('uses Rest of US when no location specified', () => {
+    const result = handleCalculateSalary({ grade: '13', step: 1 });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.locality_area).toBe('Rest of US');
+    expect(parsed.locality_percentage).toBe(17.06);
+  });
+
+  it('shows fallback message for unknown location', () => {
+    const result = handleCalculateSalary({ grade: '13', step: 1, location: 'Middle of Nowhere' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.locality_area).toBe('Rest of US');
+    expect(parsed.note).toContain('not found');
+  });
+
+  it('returns error for invalid grade', () => {
+    const result = handleCalculateSalary({ grade: '16' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Only GS grades 1-15');
+  });
+
+  it('returns error for grade range', () => {
+    const result = handleCalculateSalary({ grade: '13-14' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('single grade');
+  });
+
+  it('rounds adjusted pay to nearest dollar', () => {
+    const result = handleCalculateSalary({ grade: '1', step: 1, location: 'Raleigh' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(Number.isInteger(parsed.adjusted_pay)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- New `calculate_salary` tool: GS salary with locality pay for any grade, step, and location
- 58 locality pay areas from OPM 2026 data
- Fuzzy location matching with aliases (DC, NYC, SF, etc.)
- Rest of US fallback for unknown locations
- Sync handler — pure computation, no API calls
- Export `GS_STEPS` from glossary for reuse

Tests: 37 → 54

## Test plan
- [x] 54 tests pass
- [x] TypeScript compiles cleanly
- [x] Locality fuzzy match: aliases, substring, token overlap, fallback
- [x] Salary: specific step, all steps, grade normalization, rounding, errors