### PR TITLE
feat: add extract_ksa tool for structured KSA requirement extraction

### DIFF
--- a/src/tools/ksa.ts
+++ b/src/tools/ksa.ts
@@ -38,7 +38,7 @@ const STOP_WORDS = new Set([
 
 function splitIntoSentences(text: string): string[] {
   return text
-    .split(/[.;]\s+/)
+    .split(/[.;]\s*/)
     .map((sentence) => sentence.trim())
     .filter((sentence) => sentence.length > 3);
 }
@@ -73,25 +73,28 @@ export function parseKsaRequirements(
 function deduplicateRequirements(requirements: KsaRequirement[]): KsaRequirement[] {
   const seen = new Set<string>();
   return requirements.filter((requirement) => {
-    const normalized = requirement.text.toLowerCase().trim();
-    if (seen.has(normalized)) return false;
-    seen.add(normalized);
+    const dedupeKey = `${requirement.text.toLowerCase().trim()}::${requirement.source}`;
+    if (seen.has(dedupeKey)) return false;
+    seen.add(dedupeKey);
     return true;
   });
 }
 
 function extractMeaningfulWords(text: string): string[] {
-  return text
-    .toLowerCase()
-    .split(/[\s,\-/()]+/)
-    .filter((word) => word.length >= 3 && !STOP_WORDS.has(word));
+  return [...new Set(
+    text
+      .toLowerCase()
+      .split(/[\s,.\-:/()]+/)
+      .map((word) => word.replace(/^\W+|\W+$/g, ''))
+      .filter((word) => word.length >= 3 && !STOP_WORDS.has(word)),
+  )];
 }
 
 function matchRequirementToCV(requirement: KsaRequirement, cvContent: string): boolean {
   const words = extractMeaningfulWords(requirement.text);
   if (words.length === 0) return false;
-  const cvLower = cvContent.toLowerCase();
-  const matchedCount = words.filter((word) => cvLower.includes(word)).length;
+  const cvWords = new Set(extractMeaningfulWords(cvContent));
+  const matchedCount = words.filter((word) => cvWords.has(word)).length;
   return matchedCount / words.length >= 0.5;
 }
 

--- a/src/tools/ksa.ts
+++ b/src/tools/ksa.ts
@@ -40,7 +40,7 @@ function splitIntoSentences(text: string): string[] {
   return text
     .split(/[.;]\s+/)
     .map((sentence) => sentence.trim())
-    .filter((sentence) => sentence.length > 10);
+    .filter((sentence) => sentence.length > 3);
 }
 
 function classifySentence(sentence: string): KsaType | null {

--- a/src/tools/ksa.ts
+++ b/src/tools/ksa.ts
@@ -1,0 +1,164 @@
+import type { AxiosInstance } from 'axios';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { lookupJobById } from './search.js';
+import { requireCV } from './cv.js';
+
+export type KsaType = 'knowledge' | 'skill' | 'ability' | 'experience' | 'education' | 'certification' | 'other';
+export type KsaSource = 'qualification_summary' | 'major_duties';
+
+export interface KsaRequirement {
+  type: KsaType;
+  text: string;
+  source: KsaSource;
+  matched: boolean | null;
+}
+
+const KSA_PATTERNS: Array<{ pattern: RegExp; type: KsaType }> = [
+  { pattern: /knowledge of\b/i, type: 'knowledge' },
+  { pattern: /skill in\b/i, type: 'skill' },
+  { pattern: /skilled in\b/i, type: 'skill' },
+  { pattern: /ability to\b/i, type: 'ability' },
+  { pattern: /able to\b/i, type: 'ability' },
+  { pattern: /experience with\b/i, type: 'experience' },
+  { pattern: /experience in\b/i, type: 'experience' },
+  { pattern: /specialized experience\b/i, type: 'experience' },
+  { pattern: /\b(?:bachelor|master|phd|doctorate|degree)\b/i, type: 'education' },
+  { pattern: /\b(?:certification|certified|cissp|comptia|security\+|pmp)\b/i, type: 'certification' },
+  { pattern: /must possess\b/i, type: 'other' },
+  { pattern: /must demonstrate\b/i, type: 'other' },
+];
+
+const STOP_WORDS = new Set([
+  'the', 'and', 'for', 'with', 'that', 'this', 'from', 'are', 'was',
+  'were', 'been', 'being', 'have', 'has', 'had', 'having', 'does',
+  'did', 'will', 'would', 'could', 'should', 'may', 'might', 'must',
+  'shall', 'can', 'need', 'not', 'but', 'such', 'than', 'too', 'very',
+  'just', 'about', 'above', 'after', 'again', 'all', 'also', 'any',
+]);
+
+function splitIntoSentences(text: string): string[] {
+  return text
+    .split(/[.;]\s+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence.length > 10);
+}
+
+function classifySentence(sentence: string): KsaType | null {
+  const match = KSA_PATTERNS.find(({ pattern }) => pattern.test(sentence));
+  return match?.type ?? null;
+}
+
+export function parseKsaRequirements(
+  text: string,
+  source: KsaSource,
+): KsaRequirement[] {
+  if (!text || text.trim().length === 0) return [];
+
+  const sentences = splitIntoSentences(text);
+
+  return sentences
+    .map((sentence) => {
+      const type = classifySentence(sentence);
+      if (!type) return null;
+      return {
+        type,
+        text: sentence,
+        source,
+        matched: null as boolean | null,
+      };
+    })
+    .filter((requirement): requirement is KsaRequirement => requirement !== null);
+}
+
+function deduplicateRequirements(requirements: KsaRequirement[]): KsaRequirement[] {
+  const seen = new Set<string>();
+  return requirements.filter((requirement) => {
+    const normalized = requirement.text.toLowerCase().trim();
+    if (seen.has(normalized)) return false;
+    seen.add(normalized);
+    return true;
+  });
+}
+
+function extractMeaningfulWords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[\s,\-/()]+/)
+    .filter((word) => word.length >= 3 && !STOP_WORDS.has(word));
+}
+
+function matchRequirementToCV(requirement: KsaRequirement, cvContent: string): boolean {
+  const words = extractMeaningfulWords(requirement.text);
+  if (words.length === 0) return false;
+  const cvLower = cvContent.toLowerCase();
+  const matchedCount = words.filter((word) => cvLower.includes(word)).length;
+  return matchedCount / words.length >= 0.5;
+}
+
+export async function handleExtractKsa(
+  client: AxiosInstance,
+  params: { job_id: string },
+): Promise<CallToolResult> {
+  let item;
+  try {
+    item = await lookupJobById(client, params.job_id);
+  } catch {
+    return {
+      content: [{ type: 'text', text: 'Unable to search USAJobs at this time. Please try again later.' }],
+      isError: true,
+    };
+  }
+
+  if (!item) {
+    return {
+      content: [{
+        type: 'text',
+        text: `Job not found with ID: ${params.job_id}. The posting may have been removed or the ID may be incorrect.`,
+      }],
+      isError: true,
+    };
+  }
+
+  const descriptor = item.MatchedObjectDescriptor;
+  const details = descriptor.UserArea.Details;
+  const qualificationSummary = descriptor.QualificationSummary ?? '';
+  const majorDuties = details.MajorDuties ?? [];
+
+  const qualRequirements = parseKsaRequirements(qualificationSummary, 'qualification_summary');
+  const dutyRequirements = majorDuties.flatMap((duty) =>
+    parseKsaRequirements(duty, 'major_duties'),
+  );
+
+  const allRequirements = deduplicateRequirements([...qualRequirements, ...dutyRequirements]);
+
+  let cvContent: string | null = null;
+  try {
+    const cv = await requireCV();
+    cvContent = cv.content;
+  } catch {
+    // CV not available — matching will be skipped
+  }
+
+  const requirements = allRequirements.map((requirement) => ({
+    ...requirement,
+    matched: cvContent !== null ? matchRequirementToCV(requirement, cvContent) : null,
+  }));
+
+  const matchedCount = requirements.filter((r) => r.matched === true).length;
+  const unmatchedCount = requirements.filter((r) => r.matched === false).length;
+
+  return {
+    content: [{
+      type: 'text',
+      text: JSON.stringify({
+        job_title: descriptor.PositionTitle,
+        requirements,
+        summary: cvContent !== null
+          ? { total: requirements.length, matched: matchedCount, unmatched: unmatchedCount }
+          : { total: requirements.length },
+        cv_available: cvContent !== null,
+        raw_qualification_summary: qualificationSummary,
+      }, null, 2),
+    }],
+  };
+}

--- a/src/tools/ksa.ts
+++ b/src/tools/ksa.ts
@@ -90,11 +90,10 @@ function extractMeaningfulWords(text: string): string[] {
   )];
 }
 
-function matchRequirementToCV(requirement: KsaRequirement, cvContent: string): boolean {
+function matchRequirementToCV(requirement: KsaRequirement, cvWordSet: Set<string>): boolean {
   const words = extractMeaningfulWords(requirement.text);
   if (words.length === 0) return false;
-  const cvWords = new Set(extractMeaningfulWords(cvContent));
-  const matchedCount = words.filter((word) => cvWords.has(word)).length;
+  const matchedCount = words.filter((word) => cvWordSet.has(word)).length;
   return matchedCount / words.length >= 0.5;
 }
 
@@ -142,9 +141,11 @@ export async function handleExtractKsa(
     // CV not available — matching will be skipped
   }
 
+  const cvWordSet = cvContent !== null ? new Set(extractMeaningfulWords(cvContent)) : null;
+
   const requirements = allRequirements.map((requirement) => ({
     ...requirement,
-    matched: cvContent !== null ? matchRequirementToCV(requirement, cvContent) : null,
+    matched: cvWordSet !== null ? matchRequirementToCV(requirement, cvWordSet) : null,
   }));
 
   const matchedCount = requirements.filter((r) => r.matched === true).length;

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -4,6 +4,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { handleSearchJobs, handleGetJobDetails, handleCompareJobs } from './search.js';
 import { handleSaveCV, handleGetCV } from './cv.js';
 import { handleCalculateSalary } from './salary.js';
+import { handleExtractKsa } from './ksa.js';
 import {
   handleExplainConcept,
   handleFindMatchingJobs,
@@ -101,5 +102,14 @@ export function registerTools(server: McpServer, client: AxiosInstance): void {
       location: z.string().optional().describe('Location for locality pay: "Raleigh", "DC", "NYC", "San Francisco". Defaults to Rest of US.'),
     },
     async (params) => handleCalculateSalary(params),
+  );
+
+  server.tool(
+    'extract_ksa',
+    'Extract KSA (Knowledge, Skills, Abilities) requirements from a federal job posting. Categorizes requirements by type and optionally matches them against your saved CV. Returns structured requirements with match status.',
+    {
+      job_id: z.string().describe('Job ID (MatchedObjectId from search results)'),
+    },
+    async (params) => handleExtractKsa(client, params),
   );
 }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -106,7 +106,7 @@ export function registerTools(server: McpServer, client: AxiosInstance): void {
 
   server.tool(
     'extract_ksa',
-    'Extract KSA (Knowledge, Skills, Abilities) requirements from a federal job posting. Categorizes requirements by type and optionally matches them against your saved CV. Returns structured requirements with match status.',
+    'Extract KSA (Knowledge, Skills, Abilities) requirements from a federal job posting. Categorizes requirements by type (knowledge, skill, ability, experience, education, certification, other) and optionally matches them against your saved CV.',
     {
       job_id: z.string().describe('Job ID (MatchedObjectId from search results)'),
     },

--- a/tests/tools/ksa.test.ts
+++ b/tests/tools/ksa.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { parseKsaRequirements } from '../../src/tools/ksa.js';
+
+vi.mock('node:fs/promises');
+vi.mock('../../src/api/usajobs-client.js', () => ({
+  searchJobs: vi.fn(),
+}));
+
+function mockJobItem(overrides: Record<string, any> = {}) {
+  return {
+    MatchedObjectId: overrides.id ?? '12345',
+    MatchedObjectDescriptor: {
+      PositionTitle: overrides.title ?? 'Software Developer',
+      OrganizationName: 'SSA',
+      DepartmentName: 'SSA',
+      PositionLocationDisplay: 'Remote',
+      PositionRemuneration: [
+        { MinimumRange: '100000', MaximumRange: '150000', RateIntervalCode: 'PA' },
+      ],
+      ApplicationCloseDate: '2026-06-01',
+      PositionURI: '',
+      ApplyURI: [''],
+      JobGrade: [{ Code: 'GS' }],
+      QualificationSummary: overrides.qualifications ?? 'Knowledge of React and Node.js. Ability to lead development teams. Specialized experience equivalent to GS-12.',
+      UserArea: {
+        Details: {
+          LowGrade: '13',
+          HighGrade: '14',
+          JobSummary: '',
+          MajorDuties: overrides.duties ?? ['Skill in designing RESTful APIs.', 'Experience with cloud platforms.'],
+          HiringPath: ['public'],
+          TeleworkEligible: true,
+          RemoteIndicator: true,
+          SecurityClearance: 'Not Required',
+        },
+      },
+    },
+  };
+}
+
+describe('parseKsaRequirements', () => {
+  it('extracts knowledge requirements', () => {
+    const results = parseKsaRequirements(
+      'Knowledge of modern web frameworks such as React and Angular.',
+      'qualification_summary',
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].type).toBe('knowledge');
+    expect(results[0].text).toContain('Knowledge of modern web frameworks');
+    expect(results[0].source).toBe('qualification_summary');
+  });
+
+  it('extracts skill requirements', () => {
+    const results = parseKsaRequirements(
+      'Skill in developing RESTful APIs and microservices.',
+      'qualification_summary',
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].type).toBe('skill');
+  });
+
+  it('extracts ability requirements', () => {
+    const results = parseKsaRequirements(
+      'Ability to communicate technical concepts to non-technical stakeholders.',
+      'qualification_summary',
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].type).toBe('ability');
+  });
+
+  it('extracts experience requirements', () => {
+    const results = parseKsaRequirements(
+      'Experience with cloud computing platforms (AWS, Azure, GCP). Specialized experience equivalent to the GS-12 level.',
+      'qualification_summary',
+    );
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.type === 'experience')).toBe(true);
+  });
+
+  it('extracts education requirements', () => {
+    const results = parseKsaRequirements(
+      "Bachelor's degree in Computer Science or related field. Master's degree preferred.",
+      'qualification_summary',
+    );
+    expect(results.some((r) => r.type === 'education')).toBe(true);
+  });
+
+  it('extracts certification requirements', () => {
+    const results = parseKsaRequirements(
+      'Must possess current CISSP or Security+ certification.',
+      'qualification_summary',
+    );
+    expect(results.some((r) => r.type === 'certification')).toBe(true);
+  });
+
+  it('extracts must possess / must demonstrate patterns', () => {
+    const results = parseKsaRequirements(
+      'Must demonstrate ability to lead teams. Must possess strong analytical skills.',
+      'qualification_summary',
+    );
+    expect(results.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('handles multiple requirements separated by semicolons', () => {
+    const results = parseKsaRequirements(
+      'Knowledge of Java; Skill in database design; Ability to work independently.',
+      'qualification_summary',
+    );
+    expect(results.length).toBe(3);
+  });
+
+  it('returns empty array for text with no KSA patterns', () => {
+    const results = parseKsaRequirements(
+      'This is a general description with no specific requirements.',
+      'qualification_summary',
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty array for empty text', () => {
+    const results = parseKsaRequirements('', 'qualification_summary');
+    expect(results).toHaveLength(0);
+  });
+
+  it('sets source correctly', () => {
+    const results = parseKsaRequirements(
+      'Knowledge of Python programming.',
+      'major_duties',
+    );
+    expect(results[0].source).toBe('major_duties');
+  });
+});
+
+describe('handleExtractKsa', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('extracts requirements from job posting with CV matching', async () => {
+    const { searchJobs } = await import('../../src/api/usajobs-client.js');
+    const { handleExtractKsa } = await import('../../src/tools/ksa.js');
+
+    vi.mocked(searchJobs).mockResolvedValueOnce({
+      SearchResultCount: 1,
+      SearchResultCountAll: 1,
+      SearchResultItems: [mockJobItem()],
+    });
+
+    const stored = {
+      content: 'Senior Developer with React, Node.js, and cloud experience. Led multiple teams.',
+      savedAt: '2026-04-15T00:00:00.000Z',
+      format: 'txt',
+    };
+    vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(stored));
+
+    const client = {} as any;
+    const result = await handleExtractKsa(client, { job_id: '12345' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.job_title).toBe('Software Developer');
+    expect(parsed.requirements.length).toBeGreaterThan(0);
+    expect(parsed.cv_available).toBe(true);
+    expect(parsed.requirements.some((r: any) => r.matched === true)).toBe(true);
+    expect(parsed.summary.total).toBeGreaterThan(0);
+    expect(parsed.summary.matched).toBeDefined();
+    expect(parsed.raw_qualification_summary).toBeDefined();
+  });
+
+  it('extracts requirements without CV', async () => {
+    const { searchJobs } = await import('../../src/api/usajobs-client.js');
+    const { handleExtractKsa } = await import('../../src/tools/ksa.js');
+
+    vi.mocked(searchJobs).mockResolvedValueOnce({
+      SearchResultCount: 1,
+      SearchResultCountAll: 1,
+      SearchResultItems: [mockJobItem()],
+    });
+
+    vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('ENOENT'));
+
+    const client = {} as any;
+    const result = await handleExtractKsa(client, { job_id: '12345' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.cv_available).toBe(false);
+    expect(parsed.requirements.every((r: any) => r.matched === null)).toBe(true);
+  });
+
+  it('handles empty qualifications and duties', async () => {
+    const { searchJobs } = await import('../../src/api/usajobs-client.js');
+    const { handleExtractKsa } = await import('../../src/tools/ksa.js');
+
+    vi.mocked(searchJobs).mockResolvedValueOnce({
+      SearchResultCount: 1,
+      SearchResultCountAll: 1,
+      SearchResultItems: [mockJobItem({ qualifications: '', duties: [] })],
+    });
+
+    vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('ENOENT'));
+
+    const client = {} as any;
+    const result = await handleExtractKsa(client, { job_id: '12345' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.requirements).toHaveLength(0);
+    expect(parsed.raw_qualification_summary).toBe('');
+  });
+
+  it('returns error when job not found', async () => {
+    const { searchJobs } = await import('../../src/api/usajobs-client.js');
+    const { handleExtractKsa } = await import('../../src/tools/ksa.js');
+
+    vi.mocked(searchJobs).mockResolvedValueOnce({
+      SearchResultCount: 0,
+      SearchResultCountAll: 0,
+      SearchResultItems: [],
+    });
+
+    const client = {} as any;
+    const result = await handleExtractKsa(client, { job_id: '99999' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Job not found');
+  });
+
+  it('returns error when API fails', async () => {
+    const { searchJobs } = await import('../../src/api/usajobs-client.js');
+    const { handleExtractKsa } = await import('../../src/tools/ksa.js');
+
+    vi.mocked(searchJobs).mockRejectedValueOnce(new Error('Network error'));
+
+    const client = {} as any;
+    const result = await handleExtractKsa(client, { job_id: '12345' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Unable to search');
+  });
+});

--- a/tests/tools/ksa.test.ts
+++ b/tests/tools/ksa.test.ts
@@ -110,6 +110,14 @@ describe('parseKsaRequirements', () => {
     expect(results.length).toBe(3);
   });
 
+  it('handles semicolons without spaces', () => {
+    const results = parseKsaRequirements(
+      'Knowledge of Java;Skill in database design;Ability to work independently.',
+      'qualification_summary',
+    );
+    expect(results.length).toBe(3);
+  });
+
   it('returns empty array for text with no KSA patterns', () => {
     const results = parseKsaRequirements(
       'This is a general description with no specific requirements.',
@@ -206,6 +214,66 @@ describe('handleExtractKsa', () => {
 
     expect(parsed.requirements).toHaveLength(0);
     expect(parsed.raw_qualification_summary).toBe('');
+  });
+
+  it('matches requirement when 50%+ keywords overlap with CV', async () => {
+    const { searchJobs } = await import('../../src/api/usajobs-client.js');
+    const { handleExtractKsa } = await import('../../src/tools/ksa.js');
+
+    vi.mocked(searchJobs).mockResolvedValueOnce({
+      SearchResultCount: 1,
+      SearchResultCountAll: 1,
+      SearchResultItems: [mockJobItem({
+        qualifications: 'Knowledge of React and Angular.',
+        duties: [],
+      })],
+    });
+
+    // requirement words: "knowledge", "react", "angular" — CV has "knowledge", "react" = 2/3 = 67%
+    const stored = {
+      content: 'Strong knowledge of React development.',
+      savedAt: '2026-04-15T00:00:00.000Z',
+      format: 'txt',
+    };
+    vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(stored));
+
+    const client = {} as any;
+    const result = await handleExtractKsa(client, { job_id: '12345' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    const knowledgeReq = parsed.requirements.find((r: any) => r.type === 'knowledge');
+    expect(knowledgeReq).toBeDefined();
+    expect(knowledgeReq.matched).toBe(true);
+  });
+
+  it('does not match requirement when below 50% keyword overlap', async () => {
+    const { searchJobs } = await import('../../src/api/usajobs-client.js');
+    const { handleExtractKsa } = await import('../../src/tools/ksa.js');
+
+    vi.mocked(searchJobs).mockResolvedValueOnce({
+      SearchResultCount: 1,
+      SearchResultCountAll: 1,
+      SearchResultItems: [mockJobItem({
+        qualifications: 'Knowledge of React, Angular, Vue, TypeScript, and GraphQL frameworks.',
+        duties: [],
+      })],
+    });
+
+    // CV has only React — 1 of 5+ keywords < 50%
+    const stored = {
+      content: 'Basic React experience.',
+      savedAt: '2026-04-15T00:00:00.000Z',
+      format: 'txt',
+    };
+    vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(stored));
+
+    const client = {} as any;
+    const result = await handleExtractKsa(client, { job_id: '12345' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    const knowledgeReq = parsed.requirements.find((r: any) => r.type === 'knowledge');
+    expect(knowledgeReq).toBeDefined();
+    expect(knowledgeReq.matched).toBe(false); // below 50%
   });
 
   it('returns error when job not found', async () => {


### PR DESCRIPTION
## Summary
- New `extract_ksa` tool: parses KSA requirements from job postings
- Categorizes by type: knowledge, skill, ability, experience, education, certification
- Optional CV matching with 50% keyword overlap threshold
- Handles empty fields, missing CV, API errors gracefully

Tests: 54 → 70

## Test plan
- [x] 70 tests pass
- [x] TypeScript compiles cleanly
- [x] Parser: all KSA types, semicolons, empty text, source tracking
- [x] Handler: with CV, without CV, empty fields, job not found, API error