### PR TITLE
ci: add MCP Registry publish, fix Node 24 warning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,3 +25,11 @@ jobs:
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Install MCP Publisher
+        run: |
+          export OS=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}.tar.gz" | tar xz mcp-publisher
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: googleapis/release-please-action@v4
         with:


### PR DESCRIPTION
## Summary
- Add MCP Registry publish step to publish workflow (after npm publish)
- Force Node 24 for release-please action to suppress deprecation warning

## Test plan
- [x] MCP Registry steps follow chrome-devtools-mcp pattern
- [x] Will verify on next release