### PR TITLE
ci: auto-publish on release-please + add OpenSSF Scorecard

### DIFF
--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -2,6 +2,10 @@ name: Publish (reusable)
 
 on:
   workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: true
+        description: npm automation token used by npm publish
 
 jobs:
   publish:
@@ -12,8 +16,8 @@ jobs:
     env:
       MCP_PUBLISHER_VERSION: v1.7.9
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -28,7 +32,9 @@ jobs:
       - name: Install MCP Publisher
         run: |
           export OS=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}.tar.gz" | tar xz mcp-publisher
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}.tar.gz" -o mcp-publisher.tar.gz
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+          rm mcp-publisher.tar.gz
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc
       - name: Publish to MCP Registry

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -1,0 +1,35 @@
+name: Publish (reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      MCP_PUBLISHER_VERSION: v1.7.9
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm test
+      - run: npm run build
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Install MCP Publisher
+        run: |
+          export OS=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}.tar.gz" | tar xz mcp-publisher
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -2,10 +2,6 @@ name: Publish (reusable)
 
 on:
   workflow_call:
-    secrets:
-      NPM_TOKEN:
-        required: true
-        description: npm automation token used by npm publish
 
 jobs:
   publish:
@@ -16,8 +12,8 @@ jobs:
     env:
       MCP_PUBLISHER_VERSION: v1.7.9
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -32,9 +28,7 @@ jobs:
       - name: Install MCP Publisher
         run: |
           export OS=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}.tar.gz" -o mcp-publisher.tar.gz
-          tar -xzf mcp-publisher.tar.gz mcp-publisher
-          rm mcp-publisher.tar.gz
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}.tar.gz" | tar xz mcp-publisher
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc
       - name: Publish to MCP Registry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Publish to npm
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,8 @@ on:
 jobs:
   publish:
     uses: ./.github/workflows/_publish.yml
-    secrets: inherit
     permissions:
       contents: read
       id-token: write
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,29 +5,8 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/_publish.yml
+    secrets: inherit
     permissions:
       contents: read
       id-token: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          registry-url: https://registry.npmjs.org
-      - run: npm ci
-      - run: npx tsc --noEmit
-      - run: npm test
-      - run: npm run build
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Install MCP Publisher
-        run: |
-          export OS=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}.tar.gz" | tar xz mcp-publisher
-      - name: Login to MCP Registry
-        run: ./mcp-publisher login github-oidc
-      - name: Publish to MCP Registry
-        run: ./mcp-publisher publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,7 @@ on:
 jobs:
   publish:
     uses: ./.github/workflows/_publish.yml
+    secrets: inherit
     permissions:
       contents: read
       id-token: write
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,8 +26,7 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/_publish.yml
+    secrets: inherit
     permissions:
       contents: read
       id-token: write
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,10 +11,43 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           manifest-file: .release-please-manifest.json
           config-file: release-please-config.json
+
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm test
+      - run: npm run build
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Install MCP Publisher
+        run: |
+          export OS=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}.tar.gz" | tar xz mcp-publisher
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,8 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/_publish.yml
-    secrets: inherit
     permissions:
       contents: read
       id-token: write
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,29 +25,8 @@ jobs:
   publish:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/_publish.yml
+    secrets: inherit
     permissions:
       contents: read
       id-token: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          registry-url: https://registry.npmjs.org
-      - run: npm ci
-      - run: npx tsc --noEmit
-      - run: npm test
-      - run: npm run build
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Install MCP Publisher
-        run: |
-          export OS=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}.tar.gz" | tar xz mcp-publisher
-      - name: Login to MCP Registry
-        run: ./mcp-publisher login github-oidc
-      - name: Publish to MCP Registry
-        run: ./mcp-publisher publish

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,25 +20,25 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.2
+        uses: ossf/scorecard-action@f2ea147fec3c2f0d459703eba7405b5e9bcd8c8f # v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@fee9466b8957867761f2d78f922ab084e3e2dd17 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Coming from private sector, federal job postings feel like a different language:
 
 ## Requirements
 
-- Node.js v20+
+- Node.js v22+
 - Free [USAJobs API key](https://developer.usajobs.gov/apirequest/index)
 - Any MCP-compatible client (Claude Desktop, VS Code, Cursor, etc.)
 


### PR DESCRIPTION
## Summary

- **Auto-publish on release**: move the publish job into `release-please.yml`, gated on the `release_created` output. The previous `release:published` trigger on `publish.yml` never fired because release-please uses `GITHUB_TOKEN`, and GitHub blocks downstream workflows from token-driven events (the reason v0.1.8 was never pushed to npm).
- **`publish.yml`** now keeps only `workflow_dispatch` as a manual fallback.
- **OpenSSF Scorecard**: add `.github/workflows/scorecard.yml` so the badge in README resolves (currently shows "invalid repo path" because the project isn't indexed yet).

## Notes

- The npm publish run triggered for v0.1.8 today (run 26366031790) failed with `E404` from npm. This is unrelated to this PR — looks like the `NPM_TOKEN` secret has expired or lost publish access. Need to regenerate an automation token at npmjs.com and update the GitHub secret before this PR is useful in practice.
- Scorecard badge will start resolving after the first scheduled run lands (weekly Mon 06:00 UTC), or after the push to `main` post-merge.

## Test plan

- [ ] After merge: verify `Release Please` workflow still produces the next release PR
- [ ] Merge a release PR and confirm `publish` job runs in the same workflow (gated on `release_created`)
- [ ] Confirm `npm view federal-compass-mcp version` reflects the new version
- [ ] Confirm `scorecard.yml` runs on push to main and produces SARIF
- [ ] Reload README on GitHub and verify Scorecard badge resolves