### PR TITLE
fix: sync server.json version with release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,19 @@
     ".": {
       "release-type": "node",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[0].version"
+        }
+      ]
     }
   }
 }

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/skivuha/federal-compass-mcp",
     "source": "github"
   },
-  "version": "0.1.6",
+  "version": "0.1.9",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "federal-compass-mcp",
-      "version": "0.1.6",
+      "version": "0.1.9",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

`server.json` has been hardcoded at `0.1.6` because release-please only bumps `package.json` out of the box. As a result, every successful npm publish since v0.1.7 has been paired with a failed MCP Registry publish — \`mcp-publisher\` kept trying to publish v0.1.6 (which is already in the registry) and got back \`400 Bad Request: cannot publish duplicate version\`.

This PR:
1. Adds \`server.json\` to release-please \`extra-files\` so both \`$.version\` and \`$.packages[0].version\` get bumped automatically on every release going forward.
2. Updates the current \`server.json\` to \`0.1.9\` to backfill the bumps that release-please missed for v0.1.7 / v0.1.8 / v0.1.9.

## Impact

Once merged, I'll trigger \`publish.yml\` manually to re-run the MCP Registry publish for v0.1.9. After that, releases will be one-shot: release-please PR → merge → both npm and MCP Registry get updated automatically.

## Why MCP Registry currently shows 0.1.6

\`\`\`
$ curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.skivuha"
{ "version": "0.1.6", "isLatest": true, "publishedAt": "2026-04-15T22:02:44Z" }
\`\`\`

## Test plan

- [ ] Merge this PR
- [ ] Run \`gh workflow run publish.yml\` manually to push v0.1.9 to MCP Registry
- [ ] Verify with \`curl https://registry.modelcontextprotocol.io/v0/servers?search=io.github.skivuha\` that latest is now \`0.1.9\`
- [ ] On next release PR from release-please, verify the diff includes \`server.json\` version bumps in BOTH places