### PR TITLE
fix: report the real package version to MCP clients

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,10 @@
           "type": "json",
           "path": "server.json",
           "jsonpath": "$.packages[0].version"
+        },
+        {
+          "type": "generic",
+          "path": "src/version.ts"
         }
       ]
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { createApiClient } from './api/usajobs-client.js';
 import { registerTools } from './tools/tools.js';
 import { createLogger } from './logger.js';
+import { SERVER_VERSION } from './version.js';
 
 const log = createLogger('server');
 
@@ -38,7 +39,7 @@ async function main(): Promise<void> {
 
   const server = new McpServer({
     name: 'federal-compass',
-    version: '0.1.0',
+    version: SERVER_VERSION,
   });
 
   registerTools(server, client);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,20 @@
+/**
+ * The version reported to MCP clients during the initialize handshake.
+ *
+ * This was a bare literal in src/index.ts that release-please was never told
+ * about — no marker, no config entry — so it reported 0.1.0, a version that was
+ * never even published, across all nine releases from 0.1.1 to 0.1.9.
+ *
+ * It is now bumped by release-please via the `extra-files` entry in
+ * release-please-config.json. Two things have to stay true, and neither fails
+ * loudly if broken:
+ *
+ *   1. that config entry must still point at this file — a wrong path only
+ *      produces a buried warning in the Actions log;
+ *   2. the marker comment must stay on the SAME line as the literal, because
+ *      release-please matches line by line, so a marker one line up rewrites
+ *      nothing and logs nothing.
+ *
+ * tests/version.test.ts guards the value and both of those conditions.
+ */
+export const SERVER_VERSION = '0.1.9'; // x-release-please-version

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { SERVER_VERSION } from '../src/version.js';
+
+const readText = (relativePath: string): string =>
+  readFileSync(new URL(relativePath, import.meta.url), 'utf-8');
+
+const pkg = JSON.parse(readText('../package.json'));
+const serverManifest = JSON.parse(readText('../server.json'));
+const releaseConfig = JSON.parse(readText('../release-please-config.json'));
+
+describe('version', () => {
+  it('reports the same version to MCP clients as package.json', () => {
+    expect(SERVER_VERSION).toBe(pkg.version);
+  });
+
+  it('keeps server.json in sync with package.json', () => {
+    expect(serverManifest.version).toBe(pkg.version);
+    expect(serverManifest.packages[0].version).toBe(pkg.version);
+  });
+
+  it('is what src/index.ts hands to McpServer', () => {
+    const code = readText('../src/index.ts')
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('//'))
+      .join('\n');
+
+    expect(code).toMatch(/version:\s*SERVER_VERSION/);
+    expect(code).not.toMatch(/version:\s*['"]/);
+  });
+
+  it('keeps the release-please marker on the same line as the literal', () => {
+    expect(readText('../src/version.ts')).toMatch(
+      /SERVER_VERSION = ['"][^'"]+['"];.*x-release-please-version/,
+    );
+  });
+
+  it('is still listed in release-please extra-files', () => {
+    expect(releaseConfig.packages['.']['extra-files']).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'generic', path: 'src/version.ts' }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## The bug

`src/index.ts` hardcoded `version: '0.1.0'` in the `McpServer` constructor, and release-please was never told about it — no marker, no `extra-files` entry. So clients were told **0.1.0**, a version that was never even published, across all nine releases from 0.1.1 to 0.1.9:

```
$ initialize -> serverInfo
{ name: 'federal-compass', version: '0.1.0' }   # before
{ name: 'federal-compass', version: '0.1.9' }   # after
```

Same class of bug as the stale `server.json` fixed in #49.

## The fix

The value moves to `src/version.ts` as `SERVER_VERSION`, and `release-please-config.json` gets a third `extra-files` entry — `{"type": "generic", "path": "src/version.ts"}` — alongside the two `server.json` entries already configured there.

Worth knowing while reviewing: those `server.json` entries have **never actually executed**, because no release has been cut since they were added in #49. The first release after this merges exercises the whole extra-files mechanism for the first time. That is part of why the test below is not optional.

## Why a checked-in constant and not reading package.json at runtime

The two build outputs sit at **different depths**, so no single relative path works for both:

| Output | Path to root `package.json` |
|---|---|
| `build/src/index.js` | `../../package.json` |
| `dist/index.js` | `../package.json` |

Reading it at runtime fails three more ways, each verified rather than assumed:

- `import … with { type: 'json' }` does not compile under `module: Node16` — `TS2823`.
- Dropping the attribute typechecks **clean** and then throws `ERR_IMPORT_ATTRIBUTE_MISSING` at startup. A green CI that crashes every client is worse than the stale version.
- `package.json#files` is `["build/src", "LICENSE"]`, which excludes the `build/package.json` copy tsc emits — `ENOENT` for anyone installing from npm.
- Rollup inlines the **entire** manifest into `dist/index.js`, leaking `scripts` and `devDependencies` and growing the bundle.

Generating the file at build time was also rejected: `ci.yml` never builds, and `_publish.yml` runs `tsc --noEmit` and `npm test` *before* `npm run build`, so a gitignored generated module would break both.

## Why there is a test

Every link in this chain fails silently. release-please's `Generic` updater matches line by line and logs nothing at all when an annotation does not match; a path that does not resolve produces only a buried `warn` in the Actions log and the release still succeeds. The only loud failure is an unrecognised `type`.

So `tests/version.test.ts` covers all three links plus the wiring:

| Test | Catches |
|---|---|
| value matches `package.json` | the drift itself |
| `src/index.ts` hands the constant to `McpServer` | the literal being reintroduced |
| marker on the same line as the literal | the silent no-op |
| config still lists the file | the entry being dropped or its path typo'd |
| `server.json` in sync | the #49 bug recurring |

## Verification

Checked against `release-please@17.10.4` directly, driving its real `Generic` updater over the real file:

| Next version | Result |
|---|---|
| 0.1.10 | 1 line changed, 14 → 14 lines |
| 0.2.0 | 1 line changed, 14 → 14 lines |
| 1.0.0 | 1 line changed, 14 → 14 lines |

`addPath()` in `strategies/base.js` returns the path unchanged when the package path is `"."`, so `src/version.ts` resolves repo-root-relative as written.

Every guarded condition was confirmed to actually fail the suite when broken deliberately — reverted wiring, marker moved one line up, config entry removed, config path typo'd — while a legitimate prerelease (`1.0.0-rc.1`) keeps it green.

Also: `tsc --noEmit` clean, 78 tests pass, `npm run build` and `npm run bundle` succeed, **both** outputs report 0.1.9 over a real MCP stdio handshake with all 10 tools listed, and `build/src/version.js` ships in the npm tarball (`npm pack --dry-run`).

## Notes for review

**Merging unblocks the stalled release.** This is a conventional `fix:`, which matters beyond the bug. release-please currently reports `No user facing commits found since fecad717 - skipping` and has refused to cut a release since May, because #49 and #50 were squash-merged as `NOJIRA;`. Merging this cuts 0.1.10 and finally pushes `server.json` to the MCP Registry, which still advertises 0.1.6. Please keep a conventional squash title.

**Two of the five assertions are arguably optional.** An adversarial review argued the wiring guard and the config-entry guard have no realistic trigger here: deleting the import while keeping `SERVER_VERSION` is a compile error, and the repo has no formatter that would rewrite the config. Both points are fair. They are kept because each is a couple of lines, each closes a mechanic I reproduced, and guarding two of three links in a chain that has already failed twice seemed like the odd choice. Easy to drop either if you disagree.

**When the guard actually fires.** Worth knowing, and I only found it while reviewing: release-please PRs run **no CI at all** in this repo — `gh pr view 48` and `gh pr view 29` both return an empty check list, while a normal PR runs `test (22)`. That is standard GitHub behaviour, since workflows are not triggered by events from `GITHUB_TOKEN`. So a broken sync is invisible on the release PR itself. It surfaces on merge instead: `ci.yml` runs on `push: main` and goes red, and `npm test` in `_publish.yml` fails before `npm publish`. Nothing wrong reaches npm or the registry, but the tag will already exist — the same recoverable shape this repo hit at 0.1.7-0.1.9.

**Pre-existing, left alone:** editors flag `Cannot find name 'node:fs'` in test files because `tests/` is excluded from `tsconfig.json`. Four existing tests already import `node:fs/promises` the same way, so this is not new — worth a separate look if it bothers you.